### PR TITLE
fix(AiLanguageModel): use correct prompt from options object

### DIFF
--- a/src/AiLanguageModel.ts
+++ b/src/AiLanguageModel.ts
@@ -55,7 +55,7 @@ export class AiLanguageModel extends Effect.Service<AiLanguageModel>()("AiLangua
             "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent",
             {
               body: HttpBody.unsafeJson({
-                contents: [{ parts: [{ text: prompt }] }],
+                contents: [{ parts: [{ text: options.prompt }] }],
                 generationConfig: {
                   response_mime_type: "application/json",
                   response_schema: makeOpenApiSchema(options.schema),


### PR DESCRIPTION
The `generateJson` method was previously refactored to accept an options object, but the prompt was still being referenced as a standalone variable, which would cause a runtime error.

This commit updates the implementation to correctly access the prompt via `options.prompt`, aligning the function body with its updated signature and ensuring the correct content is sent to the API.