### PR TITLE
refactor(aigen): Streamline AI generation pipelines with pipe composition

### DIFF
--- a/src/GitClient.ts
+++ b/src/GitClient.ts
@@ -6,7 +6,7 @@ export class GitClient extends Effect.Service<GitClient>()("GitClient", {
     const executor = yield* CommandExecutor.CommandExecutor;
 
     const getStagedDiff = Effect.gen(function* () {
-      const getDiffCommand = Command.make("git", "diff", "--staged");
+      const getDiffCommand = Command.make("git", "diff", "--staged", "-U50");
       const diff = yield* executor
         .string(getDiffCommand)
         .pipe(Effect.orDieWith(() => "Failed to get staged diff. Is git installed?"));

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import { Command as CliCommand, Options, Prompt } from "@effect/cli";
+import { Command, Options, Prompt } from "@effect/cli";
 import { BunContext, BunRuntime } from "@effect/platform-bun";
 import { Cause, Effect, Logger, Option, String } from "effect";
 import { AiGenerator, REVIEW_COMMENT_TAG } from "./AiGenerator.js";
@@ -15,7 +15,7 @@ const repoOption = Options.text("repo").pipe(
   ),
 );
 
-const prCommand = CliCommand.make("gh", { repoOption }, ({ repoOption }) =>
+const prCommand = Command.make("gh", { repoOption }, ({ repoOption }) =>
   Effect.gen(function* () {
     const ai = yield* AiGenerator;
     const github = yield* GitHubClient;
@@ -94,7 +94,7 @@ const prCommand = CliCommand.make("gh", { repoOption }, ({ repoOption }) =>
   }),
 );
 
-const commitCommand = CliCommand.make("commit", {}, () =>
+const commitCommand = Command.make("commit", {}, () =>
   Effect.gen(function* () {
     const ai = yield* AiGenerator;
     const git = yield* GitClient;
@@ -120,9 +120,9 @@ const commitCommand = CliCommand.make("commit", {}, () =>
   }),
 );
 
-const main = CliCommand.make("gitai").pipe(CliCommand.withSubcommands([prCommand, commitCommand]));
+const main = Command.make("gitai").pipe(Command.withSubcommands([prCommand, commitCommand]));
 
-const cli = CliCommand.run(main, {
+const cli = Command.run(main, {
   name: "AI Git Assistant",
   version: "2.0.0",
 });


### PR DESCRIPTION
This PR refactors the core AI generation logic to improve code clarity, maintainability, and robustness. The primary change is moving from `Effect.gen` syntax to a more declarative `pipe` composition for all AI generation functions.

This change simplifies the control flow and makes the sequence of operations—filtering the diff, calling the AI, and formatting the result—more explicit. Additionally, a new `orDie` helper has been introduced to centralize error handling, and the git diff context has been expanded to improve generation quality.

### Changes:
- **Refactored AI Generation Pipelines:** All generation functions in `AiGenerator.ts` (`generatePrDetails`, `generateCommitMessage`, etc.) have been rewritten to use `Effect.pipe`. This makes the data flow more readable than the previous `Effect.gen` implementation.
- **Improved Error Handling:** A new `orDie` utility was added to wrap Effects and provide clear, concise error messages if a generation step fails.
- **Increased Diff Context:** The `git diff` command now uses the `-U50` flag to include 50 lines of context. This provides the AI model with more surrounding code, leading to more accurate and relevant suggestions.
- **CLI Definition Cleanup:** Renamed the `@effect/cli` import alias from `CliCommand` to `Command` for consistency.

### How to Test / What to Expect
- **Before:** The application generated content using `Effect.gen` and a default diff context.
- **After:** Run `gitai commit` or `gitai gh`. The functionality should be identical from a user's perspective, but the generated output may be of higher quality due to the increased diff context. The underlying code is now cleaner and more resilient to errors.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| src/AiGenerator.ts | Refactors AI generation functions from `Effect.gen` to a more declarative `pipe` composition and introduces an `orDie` helper for streamlined error handling. |
| src/GitClient.ts | Increases the number of context lines in the staged diff output to 50 (`-U50`) to provide more context to the AI model. |
| src/Main.ts | Replaces the `CliCommand` import alias with `Command` for consistency with the `@effect/cli` library. |
</details>