### PR TITLE
feat(cli): introduce rules command and local configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ scratchpad/*
 .env.test.local
 .env.production.local
 gitai
+.gitai/*

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 import { Command } from "@effect/cli";
 import { BunContext, BunRuntime } from "@effect/platform-bun";
-import { Cause, Effect, Layer, Logger } from "effect";
+import { Cause, Chunk, Effect, Layer, Logger } from "effect";
 import { AiGenerator } from "./services/AiGenerator/index.js";
 import { AiLanguageModel } from "./services/AiLanguageModel/index.js";
 import { cliLogger } from "./services/CliLogger.js";
@@ -9,12 +9,17 @@ import { GitClient } from "./services/GitClient.js";
 import { GitHubClient } from "./services/GitHubClient.js";
 import { CommitCommand } from "./commands/CommitCommand.js";
 import { GhCommand } from "./commands/GhCommand.js";
+import { RulesCommand } from "./commands/RulesCommand.js";
+import { LocalConfig } from "./services/LocalConfig.js";
 
-const MainCommand = Command.make("gitai").pipe(Command.withSubcommands([GhCommand, CommitCommand]));
+const MainCommand = Command.make("gitai").pipe(
+  Command.withSubcommands([GhCommand, CommitCommand, RulesCommand]),
+);
 
 const cli = Command.run(MainCommand, {
   name: "AI Git Assistant",
   version: "2.0.0",
+  executable: "gitai",
 });
 
 const MainLayer = Layer.mergeAll(
@@ -22,16 +27,22 @@ const MainLayer = Layer.mergeAll(
   AiLanguageModel.Default,
   GitHubClient.Default,
   GitClient.Default,
-).pipe(
-  Layer.provideMerge(BunContext.layer),
-  Layer.provideMerge(Logger.replace(Logger.defaultLogger, cliLogger)),
-);
+  LocalConfig.Default,
+  BunContext.layer,
+).pipe(Layer.provideMerge(Logger.replace(Logger.defaultLogger, cliLogger)));
 
 cli(process.argv).pipe(
   Effect.tapErrorCause((cause) => {
     if (Cause.isInterruptedOnly(cause)) {
       return Effect.void;
     }
+
+    const failures = Cause.failures(cause);
+    const hasQuitException = Chunk.some(failures, (failure) => failure._tag === "QuitException");
+    if (hasQuitException) {
+      return Effect.void;
+    }
+
     return Effect.logError(cause);
   }),
   Effect.provide(MainLayer),

--- a/src/commands/CommitCommand.ts
+++ b/src/commands/CommitCommand.ts
@@ -17,10 +17,8 @@ export const CommitCommand = Command.make(
       return;
     }
 
-    yield* Effect.log("Generating commit message...");
     const message = yield* ai.generateCommitMessage(diff);
-    yield* Effect.log(`Generated commit message:\n\n${message}\n`);
-
+    yield* Effect.log(message);
     const confirm = yield* Prompt.confirm({
       message: "Would you like to commit with this message?",
     });

--- a/src/commands/RulesCommand.ts
+++ b/src/commands/RulesCommand.ts
@@ -16,11 +16,9 @@ export const RulesCommand = Command.make(
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
 
-    const gitaiDir = ".gitai";
-    const rulesDir = path.join(gitaiDir, "rules");
-
-    yield* Effect.logDebug("Ensuring .gitai/rules/ directory exists...");
-    yield* fs.makeDirectory(gitaiDir, { recursive: true }).pipe(Effect.ignore);
+    const rulesDir = ".gitai/rules";
+    yield* Effect.logDebug(`Ensuring ${rulesDir} directory exists...`);
+    yield* fs.makeDirectory(rulesDir, { recursive: true }).pipe(Effect.ignore);
 
     const rulesFiles = yield* fs.readDirectory(rulesDir).pipe(
       Effect.map(Array.filter((filename) => filename.endsWith(".md"))),
@@ -42,16 +40,11 @@ export const RulesCommand = Command.make(
       value: filename,
     }));
 
-    const selectedFile = yield* Option.match(opts.pathOption, {
-      onNone: () =>
-        Prompt.select({
-          message: "Which rule file would you like to use?",
-          choices,
-        }),
-      onSome: (path) => Effect.succeed(path),
+    const selectedFile = yield* Prompt.select({
+      message: "Which rule file would you like to use?",
+      choices,
     });
-
-    yield* Effect.log(`Selected rule file: ${selectedFile}`);
+    yield* Effect.logDebug(`Selected rule file: ${selectedFile}`);
 
     // precedence: CLI option > local config > prompt user
     const targetFile = yield* Option.match(opts.pathOption, {

--- a/src/commands/RulesCommand.ts
+++ b/src/commands/RulesCommand.ts
@@ -1,0 +1,101 @@
+import { Command, Prompt, Options } from "@effect/cli";
+import { FileSystem, Path } from "@effect/platform";
+import { Effect, Array, Option } from "effect";
+import { LocalConfig } from "../services/LocalConfig.js";
+
+const pathOption = Options.text("target").pipe(
+  Options.optional,
+  Options.withDescription("The target file path to write the rules to (overrides config)."),
+);
+
+export const RulesCommand = Command.make(
+  "rules",
+  { pathOption },
+  Effect.fn(function* (opts) {
+    const localConfig = yield* LocalConfig;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+
+    const gitaiDir = ".gitai";
+    const rulesDir = path.join(gitaiDir, "rules");
+
+    yield* Effect.logDebug("Ensuring .gitai/rules/ directory exists...");
+    yield* fs.makeDirectory(gitaiDir, { recursive: true }).pipe(Effect.ignore);
+
+    const rulesFiles = yield* fs.readDirectory(rulesDir).pipe(
+      Effect.map(Array.filter((filename) => filename.endsWith(".md"))),
+      Effect.catchAll(() => Effect.succeed([])),
+    );
+
+    if (Array.isEmptyArray(rulesFiles)) {
+      yield* Effect.logError(
+        `No rule files found in ${rulesDir}/\n• Please create some .md files in ${rulesDir}/ to define your rules.\n• Example: echo "Your rules content here" > ${rulesDir}/my-rules.md`,
+      );
+      return;
+    }
+
+    yield* Effect.logDebug(`Found ${rulesFiles.length} rule file(s):`);
+    yield* Effect.forEach(rulesFiles, (file) => Effect.log(`  - ${file}`));
+
+    const choices = rulesFiles.map((filename) => ({
+      title: filename.replace(".md", ""),
+      value: filename,
+    }));
+
+    const selectedFile = yield* Option.match(opts.pathOption, {
+      onNone: () =>
+        Prompt.select({
+          message: "Which rule file would you like to use?",
+          choices,
+        }),
+      onSome: (path) => Effect.succeed(path),
+    });
+
+    yield* Effect.log(`Selected rule file: ${selectedFile}`);
+
+    // precedence: CLI option > local config > prompt user
+    const targetFile = yield* Option.match(opts.pathOption, {
+      onSome: (cliTarget) =>
+        Effect.logDebug(`Using CLI-provided target file: ${cliTarget}`).pipe(Effect.as(cliTarget)),
+      onNone: () =>
+        Option.match(localConfig.config.rules?.targetFile ?? Option.none(), {
+          onSome: (configTarget) =>
+            Effect.logDebug(`Using configured target file: ${configTarget}`).pipe(
+              Effect.as(configTarget),
+            ),
+          onNone: () =>
+            Prompt.text({
+              message: "Enter the target file path to write the rules to:",
+              default: "CLAUDE.local.md",
+            }),
+        }),
+    });
+
+    const confirm = yield* Prompt.confirm({
+      message: `Write rules to ${targetFile}?`,
+    });
+
+    if (!confirm) {
+      yield* Effect.log("Operation cancelled.");
+      return;
+    }
+
+    const ruleFilePath = path.join(rulesDir, selectedFile);
+    const ruleContent = yield* fs
+      .readFileString(ruleFilePath)
+      .pipe(
+        Effect.orDieWith((error) => `Failed to read rule file: ${ruleFilePath}\n${error.message}`),
+      );
+
+    yield* Effect.logDebug(`Writing rules to ${targetFile}...`);
+    yield* fs
+      .writeFileString(targetFile, ruleContent)
+      .pipe(
+        Effect.orDieWith(
+          (error) => `Failed to write to target file: ${targetFile}\n${error.message}`,
+        ),
+      );
+
+    yield* Effect.log(`✅ Successfully applied rules from ${selectedFile} to ${targetFile}!`);
+  }),
+);

--- a/src/services/AiGenerator/AiGenerator.ts
+++ b/src/services/AiGenerator/AiGenerator.ts
@@ -16,7 +16,7 @@ const orDie =
 
 export const REVIEW_COMMENT_TAG = "<!-- [gitai-review](https://github.com/lucas-barake/gitai) -->";
 
-export class AiGenerator extends Effect.Service<AiGenerator>()("AiGenerator", {
+export class AiGenerator extends Effect.Service<AiGenerator>()("@gitai/AiGenerator", {
   dependencies: [AiLanguageModel.Default],
   effect: Effect.gen(function* () {
     const ai = yield* AiLanguageModel;

--- a/src/services/AiGenerator/AiGenerator.ts
+++ b/src/services/AiGenerator/AiGenerator.ts
@@ -79,6 +79,7 @@ ${fileSummaries}
           model: opts.model,
           prompt: makePrDetailsPrompt(filteredDiff, opts.context),
           schema: PrDetails,
+          label: "PR details",
         })
         .pipe(
           Effect.map((details) => ({
@@ -100,6 +101,7 @@ ${fileSummaries}
           model: opts.model,
           prompt: makeCommitMessagePrompt(filteredDiff, opts.context),
           schema: CommitMessage,
+          label: "commit message",
         })
         .pipe(
           Effect.map((generated) => generated.message),
@@ -116,6 +118,7 @@ ${fileSummaries}
           model: opts.model,
           prompt: makeTitlePrompt(filteredDiff, opts.context),
           schema: PrTitle,
+          label: "PR title",
         })
         .pipe(
           Effect.map((generated) => generated.title),
@@ -132,6 +135,7 @@ ${fileSummaries}
           model: opts.model,
           prompt: makeReviewPrompt(filteredDiff, opts.context),
           schema: PrReviewDetails,
+          label: "PR review",
         })
         .pipe(Effect.map(formatReviewAsMarkdown), orDie("Failed to generate review"));
     });

--- a/src/services/AiLanguageModel/AiLanguageModel.ts
+++ b/src/services/AiLanguageModel/AiLanguageModel.ts
@@ -1,30 +1,23 @@
-import {
-  FetchHttpClient,
-  HttpBody,
-  HttpClient,
-  HttpClientRequest,
-  HttpClientResponse,
-} from "@effect/platform";
-import { Config, Effect, Redacted, Schedule, Schema } from "effect";
+import { FetchHttpClient, HttpBody, HttpClient, HttpClientRequest } from "@effect/platform";
+import { Config, Effect, Redacted, Schedule, Schema, Stream } from "effect";
 import { makeOpenApiSchema } from "./make-open-api-schema.js";
 
-const makeSchemaFromResponse = <A, I>(schema: Schema.Schema<A, I>) =>
-  Schema.Struct({
-    candidates: Schema.Tuple(
+class StreamChunk extends Schema.Class<StreamChunk>("StreamChunk")({
+  candidates: Schema.optional(
+    Schema.Tuple(
       Schema.Struct({
         content: Schema.Struct({
-          parts: Schema.Tuple(
-            Schema.Struct({
-              parsed: Schema.parseJson(schema).pipe(
-                Schema.propertySignature,
-                Schema.fromKey("text"),
-              ),
-            }),
-          ),
+          parts: Schema.Tuple(Schema.Struct({ text: Schema.String })),
         }),
       }),
     ),
-  });
+  ),
+  usageMetadata: Schema.Struct({
+    promptTokenCount: Schema.optional(Schema.Number),
+    candidatesTokenCount: Schema.optional(Schema.Number),
+    totalTokenCount: Schema.optional(Schema.Number),
+  }),
+}) {}
 
 export const AiModel = Schema.Literal("gemini-2.5-pro", "gemini-2.5-flash").annotations({
   description: "The model to use for AI generation",
@@ -35,6 +28,7 @@ export interface GenerateObjectOptions<A, I extends Record<string, unknown>> {
   readonly model: AiModel;
   readonly prompt: string;
   readonly schema: Schema.Schema<A, I>;
+  readonly label: string;
 }
 
 export class AiLanguageModel extends Effect.Service<AiLanguageModel>()("@gitai/AiLanguageModel", {
@@ -46,7 +40,6 @@ export class AiLanguageModel extends Effect.Service<AiLanguageModel>()("@gitai/A
       HttpClient.mapRequest((request) =>
         request.pipe(HttpClientRequest.setHeader("x-goog-api-key", Redacted.value(apiKey))),
       ),
-      HttpClient.tap((response) => response.text.pipe(Effect.flatMap(Effect.logDebug))),
       HttpClient.retryTransient({
         times: 3,
         schedule: Schedule.exponential("1 second", 2),
@@ -57,7 +50,7 @@ export class AiLanguageModel extends Effect.Service<AiLanguageModel>()("@gitai/A
       <A, I extends Record<string, unknown>>(options: GenerateObjectOptions<A, I>) =>
         httpClient
           .post(
-            `https://generativelanguage.googleapis.com/v1beta/models/${options.model}:generateContent`,
+            `https://generativelanguage.googleapis.com/v1beta/models/${options.model}:streamGenerateContent?alt=sse`,
             {
               body: HttpBody.unsafeJson({
                 contents: [{ parts: [{ text: options.prompt }] }],
@@ -69,10 +62,53 @@ export class AiLanguageModel extends Effect.Service<AiLanguageModel>()("@gitai/A
             },
           )
           .pipe(
-            Effect.flatMap(
-              HttpClientResponse.schemaBodyJson(makeSchemaFromResponse(options.schema)),
+            (self) =>
+              Effect.zipRight(
+                Effect.sync(() => {
+                  process.stdout.write(`→ Pondering ${options.label}...`);
+                }),
+                self,
+              ),
+            Effect.flatMap((response) =>
+              response.stream.pipe(
+                Stream.decodeText("utf-8"),
+                Stream.splitLines,
+                Stream.filter((line) => line.startsWith("data:") && line !== "data: [DONE]"),
+                Stream.map((line) => line.slice(5)),
+                Stream.mapEffect(Schema.decode(Schema.parseJson(StreamChunk))),
+                Stream.orDieWith((error) => `Failed to decode stream chunk: ${error.message}`),
+                Stream.runFold(
+                  { totalText: "", lastTokenCount: 0, firstChunk: true },
+                  (acc, chunk) => {
+                    const newText = chunk.candidates?.[0]?.content.parts[0].text ?? "";
+                    const updatedText = acc.totalText + newText;
+                    const tokenCount = chunk.usageMetadata.totalTokenCount ?? acc.lastTokenCount;
+
+                    if (acc.firstChunk) {
+                      process.stdout.write("\r" + " ".repeat(60) + "\r");
+                    }
+                    process.stdout.write(
+                      `\r→ Generating ${options.label}... ${tokenCount} total tokens`,
+                    );
+
+                    return {
+                      totalText: updatedText,
+                      lastTokenCount: tokenCount,
+                      firstChunk: false,
+                    };
+                  },
+                ),
+                Effect.tap(({ lastTokenCount }) =>
+                  Effect.sync(() => {
+                    process.stdout.write("\r" + " ".repeat(60) + "\r");
+                    console.log(`✓ Generated ${options.label} (${lastTokenCount} total tokens)\n`);
+                  }),
+                ),
+                Effect.map(({ totalText }) => totalText),
+                Effect.flatMap(Schema.decode(Schema.parseJson(options.schema))),
+                Effect.orDieWith((error) => `\nFailed to decode final result: ${error.message}`),
+              ),
             ),
-            Effect.map((response) => response.candidates[0].content.parts[0].parsed),
           ),
     );
 

--- a/src/services/AiLanguageModel/AiLanguageModel.ts
+++ b/src/services/AiLanguageModel/AiLanguageModel.ts
@@ -37,7 +37,7 @@ export interface GenerateObjectOptions<A, I extends Record<string, unknown>> {
   readonly schema: Schema.Schema<A, I>;
 }
 
-export class AiLanguageModel extends Effect.Service<AiLanguageModel>()("AiLanguageModel", {
+export class AiLanguageModel extends Effect.Service<AiLanguageModel>()("@gitai/AiLanguageModel", {
   dependencies: [FetchHttpClient.layer],
   effect: Effect.gen(function* () {
     const apiKey = yield* Config.redacted("GOOGLE_AI_API_KEY");

--- a/src/services/GitClient.ts
+++ b/src/services/GitClient.ts
@@ -1,8 +1,10 @@
 import { Command, CommandExecutor } from "@effect/platform";
 import { Effect, Option } from "effect";
 import { OptionsContext } from "@/Options.js";
+import { BunContext } from "@effect/platform-bun";
 
-export class GitClient extends Effect.Service<GitClient>()("GitClient", {
+export class GitClient extends Effect.Service<GitClient>()("@gitai/GitClient", {
+  dependencies: [BunContext.layer],
   effect: Effect.gen(function* () {
     const executor = yield* CommandExecutor.CommandExecutor;
 

--- a/src/services/GitHubClient.ts
+++ b/src/services/GitHubClient.ts
@@ -1,6 +1,7 @@
 import { Command, CommandExecutor } from "@effect/platform";
 import { Effect, Schema } from "effect";
 import { constant } from "effect/Function";
+import { BunContext } from "@effect/platform-bun";
 
 const PrComment = Schema.Struct({
   id: Schema.String,
@@ -9,7 +10,8 @@ const PrComment = Schema.Struct({
 
 const PrCommentArray = Schema.Array(PrComment);
 
-export class GitHubClient extends Effect.Service<GitHubClient>()("GitHubClient", {
+export class GitHubClient extends Effect.Service<GitHubClient>()("@gitai/GitHubClient", {
+  dependencies: [BunContext.layer],
   effect: Effect.gen(function* () {
     const executor = yield* CommandExecutor.CommandExecutor;
 

--- a/src/services/LocalConfig.ts
+++ b/src/services/LocalConfig.ts
@@ -1,0 +1,53 @@
+import { FileSystem, Path } from "@effect/platform";
+import { BunContext } from "@effect/platform-bun";
+import { Effect, Option, Schema } from "effect";
+import { AiModel } from "./AiLanguageModel/AiLanguageModel.js";
+
+export const DefaultAiModel = Schema.Literal("fast", "accurate").pipe(
+  Schema.transform(AiModel, {
+    decode: (value) => (value === "fast" ? "gemini-2.5-flash" : "gemini-2.5-pro"),
+    encode: (value) => (value === "gemini-2.5-flash" ? "fast" : "accurate"),
+    strict: true,
+  }),
+);
+export type DefaultAiModel = typeof DefaultAiModel.Type;
+
+export class LocalConfigSchema extends Schema.Class<LocalConfigSchema>("LocalConfigSchema")({
+  rules: Schema.optional(
+    Schema.Struct({
+      targetFile: Schema.optionalWith(Schema.String, { as: "Option" }),
+    }),
+  ),
+  defaultModel: Schema.optionalWith(DefaultAiModel, { as: "Option" }),
+}) {}
+
+export class LocalConfig extends Effect.Service<LocalConfig>()("@gitai/LocalConfig", {
+  dependencies: [BunContext.layer],
+  effect: Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+
+    const getConfig: Effect.Effect<LocalConfigSchema> = fs
+      .readFileString(path.join(".gitai", "config.json"))
+      .pipe(
+        Effect.flatMap(
+          Schema.decode(Schema.parseJson(LocalConfigSchema), {
+            errors: "all",
+            onExcessProperty: "error",
+          }),
+        ),
+        Effect.tapError((error) =>
+          Effect.logWarning(`[LocalConfig]: Failed to read config: ${error.message}`),
+        ),
+        Effect.orElseSucceed(
+          (): LocalConfigSchema => ({
+            defaultModel: Option.none(),
+          }),
+        ),
+      );
+
+    return {
+      config: yield* getConfig,
+    } as const;
+  }),
+}) {}


### PR DESCRIPTION
This change introduces local configuration and a new `rules` command to make the tool more flexible and user-friendly. Users can now create a `.gitai/config.json` file to set a default AI model and other settings. The new `rules` command helps manage and apply different sets of instructions (e.g., for different AI personas) from files stored in `.gitai/rules/`.

Additionally, the AI interaction has been updated to use streaming, providing real-time feedback on generation progress in the terminal.

### Changes:
- **Local Configuration**: Added support for a `.gitai/config.json` file, allowing users to set a `defaultModel` ('fast' or 'accurate') and a target file for rules.
- **New `rules` Command**: Introduced the `gitai rules` command to select a rule file from `.gitai/rules/*.md` and write its content to a target file, useful for managing AI instruction sets.
- **Streaming AI Responses**: Reworked the AI client to stream responses, displaying a live token count and progress indicator instead of a long, silent wait.
- **Improved Logging**: The CLI logger has been revamped for cleaner, more intuitive output, distinguishing between informational messages, progress updates, and errors.

### How to Test / What to Expect
**Before**: Running `gitai commit` involved a long wait with no feedback. The default model could only be changed with the `--model` flag. There was no way to manage rule files.

**After**:
1. Run `gitai commit`. You should now see real-time progress, like `→ Generating commit message... X total tokens`.
2. Create a `.gitai/config.json` with `{ "defaultModel": "accurate" }`. Run `gitai commit` without a `--model` flag. The logs should confirm it's using `gemini-2.5-pro`.
3. Create a directory `.gitai/rules/` and add a `test.md` file inside it. Run `gitai rules`. The command should prompt you to select `test` and then ask where to write the file's contents.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| .gitignore | Add the `.gitai/` directory to the ignore list to avoid committing local configuration and rules. |
| src/Main.ts | Integrate the new `RulesCommand` and `LocalConfig` service, and add error handling for user-cancelled prompts. |
| src/Options.ts | Refactor model option handling to prioritize CLI flags, then local configuration from `.gitai/config.json`, before falling back to the default. |
| src/commands/CommitCommand.ts | Streamline logging output by removing redundant messages, relying on the new streaming progress indicator. |
| src/commands/RulesCommand.ts | Add a new `rules` command for selecting and applying rule files from `.gitai/rules/` to a target file. |
| src/services/AiGenerator/AiGenerator.ts | Add a descriptive `label` to AI generation calls to improve progress messages in the terminal. |
| src/services/AiLanguageModel/AiLanguageModel.ts | Rearchitect the AI client to use streaming SSE responses, providing real-time token count and progress feedback to the user. |
| src/services/CliLogger.ts | Revamp the CLI logger for improved readability, using badges for log levels and better formatting for progress and structured data. |
| src/services/GitClient.ts | Scope the service tag to `@gitai/GitClient` and add the `BunContext` dependency. |
| src/services/GitHubClient.ts | Scope the service tag to `@gitai/GitHubClient` and add the `BunContext` dependency. |
| src/services/LocalConfig.ts | Introduce a new service to read and parse user-defined configuration from `.gitai/config.json`, allowing for project-specific settings. |
</details>